### PR TITLE
Fix profile image zoom after refresh

### DIFF
--- a/app/components/ProfileSection.tsx
+++ b/app/components/ProfileSection.tsx
@@ -10,7 +10,8 @@ const ProfileSection = () => {
                                                        src="/portrait.png"
                                                        alt="Profile"
                                                        fill
-                                                       className="object-cover object-center"
+                                                       className="object-cover object-[50%_20%]"
+                                                       style={{ objectPosition: '50% 20%' }}
                                                        priority
                                                         />
 					</div>


### PR DESCRIPTION
## Summary
- keep profile photo centered so it doesn't shift after refresh

## Testing
- `npm test --silent`
